### PR TITLE
Support Debian Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Example Playbook
 License
 -------
 
-LGPLv3
+LGPL-3.0
 
 Author Information
 ------------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Jasper N. Brouwer, Ramon de la Fuente"
   description: Generate localisation files from templates and configure locale environment variables
   company: Future500
-  license: LGPL
+  license: LGPL-3.0
   min_ansible_version: 1.4
   platforms:
   - name: Debian

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,8 @@ galaxy_info:
   - name: Debian
     versions:
       - wheezy
+      - jessie
+      - stretch
   galaxy_tags:
     - system
 dependencies: []


### PR DESCRIPTION
Add up to Stretch to supported Debian versions & Specify license version (LGPL-3.0).

After merge I recommend tagging `v1.0.0`.